### PR TITLE
Some fixes and improvements

### DIFF
--- a/RKA/Session.php
+++ b/RKA/Session.php
@@ -44,7 +44,7 @@ final class Session
 
     public function __set($key, $value)
     {
-        return $this->set($key, $value);
+        $this->set($key, $value);
     }
 
     public function __get($key)
@@ -59,6 +59,6 @@ final class Session
 
     public function __unset($key)
     {
-        return $this->delete($key);
+        $this->delete($key);
     }
 }

--- a/RKA/SessionMiddleware.php
+++ b/RKA/SessionMiddleware.php
@@ -11,22 +11,21 @@ use Slim\Middleware;
 
 final class SessionMiddleware extends Middleware
 {
-    protected $options = [
-        'name' => 'RKA',
-        'lifetime' => 7200,
-        'path' => null,
-        'domain' => null,
-        'secure' => false,
-        'httponly' => true,
-    ];
+    protected $options;
 
     public function __construct($options = [])
     {
-        $keys = array_keys($this->options);
-        foreach ($keys as $key) {
-            if (array_key_exists($key, $options)) {
-                $this->options[$key] = $options[$key];
-            }
+        $defaults = [
+          'name' => 'RKA',
+          'lifetime' => 7200,
+          'path' => '/',
+          'domain' => null,
+          'secure' => false,
+          'httponly' => false,
+        ];
+        $this->options = array_merge($defaults, $options);
+        if (is_string($lifetime = $this->options['lifetime'])) {
+            $this->options['lifetime'] = strtotime($lifetime) - time();
         }
     }
 
@@ -43,15 +42,13 @@ final class SessionMiddleware extends Middleware
         }
 
         $options = $this->options;
-        $current = session_get_cookie_params();
-        
-        $lifetime = (int)($options['lifetime'] ?: $current['lifetime']);
-        $path     = $options['path'] ?: $current['path'];
-        $domain   = $options['domain'] ?: $current['domain'];
-        $secure   = (bool)$options['secure'];
-        $httponly = (bool)$options['httponly'];
-
-        session_set_cookie_params($lifetime, $path, $domain, $secure, $httponly);
+        session_set_cookie_params(
+            $options['lifetime'],
+            $options['path'],
+            $options['domain'],
+            $options['secure'],
+            $options['httponly']
+        );
         session_name($options['name']);
         session_cache_limiter(false); //http://docs.slimframework.com/#Sessions
         session_start();

--- a/tests/RKATest/SessionMiddlewareTest.php
+++ b/tests/RKATest/SessionMiddlewareTest.php
@@ -24,10 +24,10 @@ class SessionMiddlewareTest extends \PHPUnit_Framework_TestCase
             'path' => '/',
             'domain' => '',
             'secure' => false,
-            'httponly' => true,
+            'httponly' => false,
         ];
         $this->assertEquals($expected, session_get_cookie_params());
-        
+
         $this->assertEquals(PHP_SESSION_ACTIVE, session_status());
         $this->assertEquals('RKA', session_name());
     }
@@ -36,7 +36,7 @@ class SessionMiddlewareTest extends \PHPUnit_Framework_TestCase
     {
         $session = new SessionMiddleware([
             'name' => 'Test',
-            'lifetime' => '3600',
+            'lifetime' => 3600,
             'path' => '/test',
             'domain' => 'example.com',
             'secure' => true,
@@ -54,7 +54,7 @@ class SessionMiddlewareTest extends \PHPUnit_Framework_TestCase
             'httponly' => false,
         ];
         $this->assertEquals($expected, session_get_cookie_params());
-        
+
         $this->assertEquals(PHP_SESSION_ACTIVE, session_status());
         $this->assertEquals('Test', session_name());
     }


### PR DESCRIPTION
I was looking at the code and there are some things that can be improved, mostly in the options. Also, there are some `return` statements in `Session.php` that should be removed (return type is `void`).
Then, in the options, since the middleware is for Slim framework and there are some convention in configuration keys, there is a need to, for example, allow the user set `lifetime` to `20 minutes`.
For reference, the `SessionCookie` Slim built-in middleware was used.
