### PR TITLE
Fix session lifetime (server - cookie sync) and expiration algorithm

### DIFF
--- a/RKA/SessionMiddleware.php
+++ b/RKA/SessionMiddleware.php
@@ -84,7 +84,7 @@ final class SessionMiddleware
 
         $_SESSION['_idle'] = time();
 
-        // Manually extend session cookie expiry on each request (http://php.net/manual/en/function.session-set-cookie-params.php#100657)
+        // Manually extend session cookie expiry on each request
         if ($request->getCookieParam($options['name']) === $sessionId) {
             setcookie($options['name'], $sessionId, time() + $lifetime, $path, $domain, $secure, $httponly);
         }


### PR DESCRIPTION
At this moment session lifetime is absolute and only set in cookie.

It means that
- server session is extended on each request, but cookie expiration date is not.
- server session lifetime is not in sync with cookie expiration
- server session lifetime is not set by middleware. Instead it's read from the `session.gc_maxlifetime` setting

This PR:
- sets server session lifetime to the `lifetime` option
- makes sure only cookies are used for session (not the SID query parameter)
- extends cookie expiration on each request to be in sync with server session
- expires the session when lifetime option passes (user is inactive/ no new requests since `_idle` time)

Resources:
- Syncing cookie expiration with server lifetime: http://php.net/manual/en/function.session-set-cookie-params.php#100657
- Proper setting server lifetime and manual session timeout algorithm
http://stackoverflow.com/questions/520237/how-do-i-expire-a-php-session-after-30-minutes?noredirect=1&lq=1