### PR TITLE
Remove final keyword from class definitions

### DIFF
--- a/RKA/Session.php
+++ b/RKA/Session.php
@@ -8,7 +8,7 @@
  */
 namespace RKA;
 
-final class Session
+class Session
 {
     public static function regenerate()
     {

--- a/RKA/SessionMiddleware.php
+++ b/RKA/SessionMiddleware.php
@@ -10,7 +10,7 @@ namespace RKA;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-final class SessionMiddleware
+class SessionMiddleware
 {
     protected $options = [
         'name' => 'RKA',


### PR DESCRIPTION
So it's possible to extend classes.
Example: Custom expiration algorithms, handlers, etc