### PR TITLE
Replace static methods #18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 /build
 /.phpunit.result.cache
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /vendor
 /build
 /.phpunit.result.cache
-/.idea/

--- a/README.md
+++ b/README.md
@@ -4,37 +4,54 @@ Middleware for [Slim Framework][1] that starts a session. Also provides a useful
 
 ## Installation
 
-    composer require "akrabat/rka-slim-session-middleware"
+```
+composer require "akrabat/rka-slim-session-middleware"
+```
 
 ## Usage
 
 Add middleware as usual:
 
-    $app->add(new \RKA\SessionMiddleware(['name' => 'MySessionName']));
-
+```php
+$app->add(new \RKA\SessionMiddleware(['name' => 'MySessionName']));
+```
 
 ### RKA\Session
 
 You can use `\RKA\Session` to access session variables. The main thing that this gives you is defaults and an OO interface:
 
-    $app->get('/', function ($request, $response) {
-        $session = new \RKA\Session();
+```php
+$app->get('/', function ($request, $response) {
+    $session = new \RKA\Session();
 
-        // Get session variable:
-        $foo = $session->get('foo', 'some-default');
-        $bar = $session->bar;
+    // Get session variable:
+    $foo = $session->get('foo', 'some-default');
+    $bar = $session->bar;
 
-        // Set session variable:
-        $session->foo = 'this';
-        $session->set('bar', 'that');
+    // Set session variable:
+    $session->foo = 'this';
+    $session->set('bar', 'that');
 
-        return $response;
-    });
+    return $response;
+});
+```
 
+If you need to clear or destroy the session, you can do:
 
-if you need to destroy the session, you can do:
+```php
+$session = new \RKA\Session();
 
-    \RKA\Session::destroy();
+// Delete a session variable
+$session->delete('foo');
 
+// Clear all session variables
+$session->clearAll();
+
+// Clear and destroy the session
+$session->destroy();
+
+// Generate a new session id
+$session->regenerate();
+```
 
 [1]: http://www.slimframework.com/

--- a/RKA/Session.php
+++ b/RKA/Session.php
@@ -10,14 +10,14 @@ namespace RKA;
 
 final class Session
 {
-    public static function regenerate(): void
+    public function regenerate(): void
     {
         if (session_status() === PHP_SESSION_ACTIVE) {
             session_regenerate_id(true);
         }
     }
 
-    public static function destroy(): void
+    public function destroy(): void
     {
         $_SESSION = [];
 

--- a/composer.json
+++ b/composer.json
@@ -28,19 +28,7 @@
         }
     },
     "scripts": {
-        "cs:check": "php-cs-fixer fix --dry-run --format=txt --verbose --diff --config=.cs.php --ansi",
-        "cs:fix": "php-cs-fixer fix --config=.cs.php --ansi",
-        "sniffer:check": "phpcs --standard=phpcs.xml",
-        "sniffer:fix": "phpcbf --standard=phpcs.xml",
-        "stan": "phpstan analyse -c phpstan.neon --no-progress --ansi",
-        "start": "php -S localhost:8080 -t public/",
         "test": "phpunit --configuration phpunit.xml --do-not-cache-result --colors=always",
-        "test:all": [
-            "@cs:check",
-            "@sniffer:check",
-            "@stan",
-            "@test"
-        ],
         "test:coverage": "php -d xdebug.mode=coverage -r \"require 'vendor/bin/phpunit';\" -- --configuration phpunit.xml --do-not-cache-result --colors=always --coverage-clover build/logs/clover.xml --coverage-html build/coverage"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,21 @@
         "psr-4": {
             "RKA\\": "RKA"
         }
+    },
+    "scripts": {
+        "cs:check": "php-cs-fixer fix --dry-run --format=txt --verbose --diff --config=.cs.php --ansi",
+        "cs:fix": "php-cs-fixer fix --config=.cs.php --ansi",
+        "sniffer:check": "phpcs --standard=phpcs.xml",
+        "sniffer:fix": "phpcbf --standard=phpcs.xml",
+        "stan": "phpstan analyse -c phpstan.neon --no-progress --ansi",
+        "start": "php -S localhost:8080 -t public/",
+        "test": "phpunit --configuration phpunit.xml --do-not-cache-result --colors=always",
+        "test:all": [
+            "@cs:check",
+            "@sniffer:check",
+            "@stan",
+            "@test"
+        ],
+        "test:coverage": "php -d xdebug.mode=coverage -r \"require 'vendor/bin/phpunit';\" -- --configuration phpunit.xml --do-not-cache-result --colors=always --coverage-clover build/logs/clover.xml --coverage-html build/coverage"
     }
 }

--- a/tests/RKATest/SessionTest.php
+++ b/tests/RKATest/SessionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace RKATest;
 
 use PHPUnit\Framework\TestCase;
@@ -76,7 +77,9 @@ class SessionTest extends TestCase
     {
         @session_start();
         $this->assertEquals(PHP_SESSION_ACTIVE, session_status());
-        @Session::destroy(); // silence headers already sent warning
+        $session = new Session;
+        $session->destroy();
+        // silence headers already sent warning
         $this->assertEquals(PHP_SESSION_NONE, session_status());
     }
 }


### PR DESCRIPTION
This PR replaces the static Session method with non-static methods.

Affected methods:

* `RKA\Session::regenerate()`
* `RKA\Session::destroy()`

See #18

